### PR TITLE
Fix cell selector to only look at data cells

### DIFF
--- a/main.js
+++ b/main.js
@@ -11,14 +11,14 @@ bisSum = function(selector){
     date_to.setHours(16);
     date_to.setMinutes(30);
     var dat = new Date;
-    var time = $(this).children().eq(2).text().split(/\:|\-/g);
-    var payDate = $(this).children().eq(1).text();
+    var time = $(this).children('.reportDataTd').eq(2).text().split(/\:|\-/g);
+    var payDate = $(this).children('.reportDataTd').eq(1).text();
     // console.log(payDate.trim());
     dat.setHours(time[0]);
     dat.setMinutes(time[1]);
     // console.log("date_from: " + date_from + " date_to: " + date_to + " dat: " + dat);
     if (dat>date_from && dat<date_to) {
-      var curr_price = Number($(this).children().eq(5).text().replace(/[^\d.-]/g,''));
+      var curr_price = Number($(this).children('.reportDataTd').eq(5).text().replace(/[^\d.-]/g,''));
       sum += curr_price;
       if (payDate != lastDate) {
         days += 1;


### PR DESCRIPTION
Fixes issue with `+` sign in the table, which adds an extra cell to the beginning of the `children` array.

This fixes it to only look at cells with the `reportDataTd` class, and the `+` sign’s row doesn’t.